### PR TITLE
FEAT: add article

### DIFF
--- a/src/assets/ContentModel.ts
+++ b/src/assets/ContentModel.ts
@@ -123,20 +123,20 @@ road_address_name: "서울 종로구 평창문화로 19"
   ] as any
 }
 
-export const myPlaces = {
-  smu: {
+export const myPlaces = [
+  {
     id: 0,
-    name:'상명대 맛집모듬.zip',
-    tags: ['#종로', '#언덕싫어', '#학식싫어', '#찐맛집']
+    name: '상명대 맛집모듬.zip',
+    tags: ['#종로', '#언덕싫어', '#학식싫어', '#찐맛집'],
   },
-  gangnam: {
+  {
     id: 0,
-    name:'강남핫플 카페',
+    name: '강남핫플 카페',
     tags: ['#강남', '#강남역', '#사람많아', '#커피비싸', '#사진맛집']
   },
-  jongro: {
+  {
     id: 0,
-    name:'종로 밥집',
+    name: '종로 밥집',
     tags: ['#종로', '#종각', '#종조로종종', '#로컬맛집']
   }
-}
+]

--- a/src/components/MainDrawer.vue
+++ b/src/components/MainDrawer.vue
@@ -1,0 +1,112 @@
+<template>
+  <q-header elevated class="bg-cyan-8 flex column" style="heigt: 5vh">
+    <q-toolbar>
+      <q-toolbar-title>
+        수뭉이네 밥집
+      </q-toolbar-title>
+      <q-btn flat @click="drawer = !drawer" round dense icon="menu" />
+    </q-toolbar>
+  </q-header>
+
+  <q-drawer
+    v-model="drawer"
+    show-if-above
+    :width="400"
+    :breakpoint="600"
+  >
+    <q-dialog v-model="this.dialog" :position="this.position">
+      <q-card style="width: 350px" class="flex column content-center">
+        <q-card-section class="row items-center no-wrap">
+          <div>
+            <q-input outlined v-model="id" label="id입력" />
+            <q-btn style="width: 100%;" color="white" text-color="black" label="요청" />
+          </div>
+          <q-space />
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+    <q-scroll-area style="height: calc(100% - 150px); margin-top: 150px; border-right: 1px solid #ddd">
+      <q-list padding>
+        <q-item clickable v-ripple>
+          <q-item-section avatar>
+            <q-icon name="star" />
+          </q-item-section>
+          <q-item-section>
+            내 즐겨찾기 모음
+          </q-item-section>
+        </q-item>
+        <q-item clickable v-ripple to="/article/themes">
+          <q-item-section avatar>
+            <q-icon name="edit" />
+          </q-item-section>
+          <q-item-section>
+            게시글 작성
+          </q-item-section>
+        </q-item>
+        <q-item clickable v-ripple @click="open('top')">
+          <q-item-section avatar>
+            <q-icon name="add" />
+          </q-item-section>
+          <q-item-section>
+            친구 추가
+          </q-item-section>
+        </q-item>
+        <div style="margin: 20px;">
+          <q-input style="margin: 5px" v-model="hashTagFilter" label="해쉬태그 필터" :dense="true" />
+          <q-input style="margin: 5px" v-model="placeFilter" label="지역구 필터" :dense="true" />
+        </div>
+        <q-item clickable v-ripple>
+          <q-item-section avatar>
+            <q-icon name="casino" />
+          </q-item-section>
+          <q-item-section>
+            나는 오늘 뭘 먹을까
+          </q-item-section>
+        </q-item>
+        <q-item clickable v-ripple>
+          <q-item-section avatar>
+            <q-icon name="face" />
+          </q-item-section>
+          <q-item-section>
+            마이페이지
+          </q-item-section>
+        </q-item>
+      </q-list>
+
+    </q-scroll-area>
+
+    <q-img class="absolute-top" src="https://i.pinimg.com/564x/2d/de/41/2dde4170e8b2b36265057013ebe7cfd2.jpg" style="height: 150px">
+      <div class="absolute-bottom bg-transparent">
+        <q-avatar size="56px" class="q-mb-sm">
+          <img src="https://i.pinimg.com/564x/6c/ab/38/6cab3803e1d182a6c2e53fc62e821efa.jpg">
+        </q-avatar>
+        <div class="text-weight-bold text-black">농담곰</div>
+        <div  class="text-weight-bold text-black">damgom@nagano.com</div>
+      </div>
+    </q-img>
+  </q-drawer>
+</template>
+
+<script lang="ts">
+import {defineComponent, ref} from 'vue';
+import {useQuasar} from 'quasar';
+export default defineComponent({
+  name: 'MainDrawer',
+  setup () {
+    const dialog = ref(false)
+    const position = ref('top')
+    return {
+      drawer: ref(false),
+      $q: useQuasar(),
+      dialog,
+      position,
+
+      open (pos: string) {
+        position.value = pos
+        dialog.value = true
+      }
+    }
+  },
+});
+</script>
+

--- a/src/layouts/ArticleLayout.vue
+++ b/src/layouts/ArticleLayout.vue
@@ -12,7 +12,7 @@ import MainDrawer from 'components/MainDrawer.vue';
 
 
 export default defineComponent({
-  name: 'MainLayout',
+  name: 'ArticleLayout',
   components: {MainDrawer},
   setup () {
     return {

--- a/src/pages/MainPage.vue
+++ b/src/pages/MainPage.vue
@@ -1,17 +1,28 @@
 <template>
-  <q-page class="row items-center justify-evenly">
-    <router-view></router-view>
-  </q-page>
+  main page
 </template>
 
 <script lang="ts">
 import { defineComponent, ref } from 'vue';
+import {useQuasar} from 'quasar';
+
 
 export default defineComponent({
   name: 'MainPage',
-  components: { },
   setup () {
-    return {};
-  }
+    return {
+    }
+  },
+  data() {
+    return {
+      //
+    }
+  },
+  mounted() {
+    //
+  },
+  methods: {
+    //
+  },
 });
 </script>

--- a/src/pages/article/ThemesPage.vue
+++ b/src/pages/article/ThemesPage.vue
@@ -1,0 +1,119 @@
+<template>
+  <q-layout style="text-align: right; padding-top: 5vh">
+    <q-list bordered>
+      <q-item v-for="(place, key) in places" v-bind:key="key" class="q-my-sm" clickable v-ripple>
+        <q-item-section>
+          <q-item-label style="font-size: 20px;">{{ place.name }}</q-item-label>
+          <q-item-label style="font-size: 15px;" caption lines="1">
+              <span v-for="(tag, key) in place.tags" v-bind:key="key">
+                {{tag}}
+              </span>
+          </q-item-label>
+        </q-item-section>
+        <q-item-section side>
+          <q-radio v-model="shape" :val="key"/>
+        </q-item-section>
+      </q-item>
+      <q-separator/>
+    </q-list>
+  </q-layout>
+  <q-footer reveal elevated class="bg-cyan-8 justify-end">
+    <q-toolbar class="justify-between">
+      <div class="flex items-center" style="width: 100%;">
+        <q-btn icon="add" color="white" text-color="black" @click="fixed = true" label="추가하기" />
+      </div>
+      <div class="flex items-center justify-end" style="width: 100%;">
+        <q-btn to="/article/write" icon="keyboard_tab" color="white" text-color="black" label="계속 작성하기" />
+      </div>
+    </q-toolbar>
+    <q-dialog v-model="fixed">
+      <q-card style="width: 90%;">
+        <q-card-section>
+          <div class="text-h6">태그 추가하기</div>
+        </q-card-section>
+        <q-separator />
+        <q-card-section style="max-height: 50vh; height: 50vh" class="scroll">
+          <q-input outlined v-model="title" label="제목" />
+          <q-input bottom-slots v-model="tag" counter maxlength="12">
+            <template v-slot:hint>
+              태그를 추가해주세요
+            </template>
+            <template v-slot:after>
+              <q-btn
+                @click="() => { this.tags.push('#'+this.tag); this.tag = '' }"
+                round dense flat icon="send" />
+            </template>
+          </q-input>
+          <q-list>
+            <q-item clickable v-for="(tag, idx) in tags" @click="this.tags.splice(idx, 1)" v-bind:key="idx">
+              <q-item-section avatar>
+                <q-icon color="primary" name="local_bar" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{tag}}</q-item-label>
+              </q-item-section>
+            </q-item>
+          </q-list>
+        </q-card-section>
+        <q-separator />
+        <q-card-actions align="right">
+          <q-btn flat label="추가" color="primary" @click="addTag" v-close-popup />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </q-footer>
+</template>
+
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import {myPlaces} from 'assets/ContentModel';
+
+export default defineComponent({
+  name: 'ArticlePage',
+  components: { },
+  setup () {
+    return {
+      shape: ref(null),
+      fixed: ref(false),
+    }
+  },
+  data() {
+    return {
+      contentStyle: {
+        width: '100%',
+        height: '100vh',
+        display:'block',
+      },
+      places: ref<[{
+        id: number,
+        name: string,
+        tags: [],
+      }] | any>(),
+      title: ref<string>(''),
+      tag: ref<string>(''),
+      tags: ref<string[]>([])
+    }
+  },
+  async mounted() {
+    this.places = [...myPlaces]
+    this.$q.loading.show()
+    this.$q.loading.hide()
+
+  },
+  methods: {
+    addTag: function () {
+      if(this.tags.length == 0) {
+        return
+      }
+      this.places.push({
+        id: 0,
+        name: this.title,
+        tags: this.tags
+      })
+      this.tags = []
+      this.title = ''
+    },
+  },
+});
+</script>

--- a/src/pages/article/WritePage.vue
+++ b/src/pages/article/WritePage.vue
@@ -1,0 +1,213 @@
+<template>
+  <q-layout id="map" :style="mapStyle"></q-layout>
+  <q-footer reveal elevated class="bg-cyan-8 justify-end">
+    <q-input color="white" filled bottom-slots v-model="tag" label="태그를 추가해주세요" counter maxlength="12">
+      <template v-slot:after>
+        <q-btn
+          @click="() => { this.placeCategory.push(this.tag); this.tag = '' }"
+          round dense flat icon="send" />
+      </template>
+    </q-input>
+    <q-toolbar class="justify-between">
+      <q-list style="width: 100%;" class="flex row justify-start">
+        <q-item v-for="(item, key) in placeCategory" v-bind:key="key" clickable>
+          <q-item-section>
+            <q-item-label>#{{item}}</q-item-label>
+          </q-item-section>
+        </q-item>
+      </q-list>
+      <q-btn to="/main" style="width: 10%" icon="check" color="white" text-color="black"/>
+    </q-toolbar>
+  </q-footer>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import {myPlaces, placesInfos} from 'assets/ContentModel';
+
+export default defineComponent({
+  name: 'WritePage',
+  components: { },
+  setup () {
+    return {
+      myPlaces: myPlaces,
+      placesInfos: placesInfos,
+    }
+  },
+  data() {
+    return {
+      mapStyle: {
+        width: '100%',
+        height: '100vh',
+        display:'block'
+      },
+      map: ref(null),
+      infowindow: ref(null),
+      ps: ref(null),
+      searchText: ref<string>(''),
+      hashTagFilter:ref<string>(''),
+      placeFilter:ref<string>(''),
+      markers: ref<any>([]),
+      places: ref<any>([]),
+      placeCategory: ref<string[]>([]),
+      favoriteFlag: false,
+      gradeFlag: false,
+      tag: ref<string>('')
+    }
+  },
+  async mounted() {
+    this.$q.loading.show()
+    setTimeout(()=>{
+      if (!window.kakao || !window.kakao.maps) {
+        // script 태그 객체 생성
+        const script = document.createElement('script');
+        // src 속성을 추가하며 .env.local에 등록한 service 키 활용
+        // 동적 로딩을 위해서 autoload=false 추가
+        script.src =
+          '//dapi.kakao.com/v2/maps/sdk.js?autoload=false&appkey=' +
+          `${process.env.KAKAOMAP_KEY}` +
+          '&libraries=services,clusterer,drawing';
+        /* global kakao */
+        document.head.appendChild(script);
+        script.addEventListener('load', () => {
+          kakao.maps.load(this.initMap);
+        });
+      } else {
+        this.initMap();
+      }
+      this.showPlace(0)
+      this.$q.loading.hide()
+    }, 1000)
+  },
+  methods: {
+    initMap: function () {
+      setTimeout(()=>{
+        const container = document.getElementById('map')
+        const options = {
+          center: new kakao.maps.LatLng(37.566826, 126.9786567),
+          level: 5,
+        };
+        this.map = new kakao.maps.Map(container, options);
+        this.infowindow = new kakao.maps.InfoWindow({ zIndex:1 });
+        this.ps = new kakao.maps.services.Places();
+      }, 100)
+    },
+    placesSearchCB: function(data: string | any[], status: any, pagination: any) {
+      if (status === kakao.maps.services.Status.OK) {
+        // MARK: 기존 마커 삭제
+        if(this.markers.length !== 0) {
+          if(this.infowindow != null) {
+            this.infowindow.close()
+          }
+          for(let i = 0; i < this.markers.length; i++) {
+            this.markers[i].setMap(null)
+          }
+          this.markers = []
+        }
+        // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+        // LatLngBounds 객체에 좌표를 추가합니다
+        const bounds = new kakao.maps.LatLngBounds();
+        this.places = []
+        for (let i=0; i<data.length; i++) {
+          this.places.push(data[i])
+          this.displayMarker(data[i]);
+          bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
+        }
+        if(this.map != null) {
+          // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+          this.map.setBounds(bounds);
+        }
+      }
+    },
+    // 지도에 마커를 표시하는 함수입니다
+    displayMarker: function(place: { y: any; x: any; place_name: string; road_address_name:string; category_name: string }) {
+      // 마커를 생성하고 지도에 표시합니다
+      const marker = new kakao.maps.Marker({
+        map: this.map,
+        position: new kakao.maps.LatLng(place.y, place.x)
+      });
+      this.markers.push(marker)
+      // 마커에 클릭이벤트를 등록합니다
+      kakao.maps.event.addListener(marker, 'click', () => {
+        this.placeName = place.place_name
+        this.placeAddress = place.road_address_name
+        this.placeCategory = place.category_name.split(' > ')
+        if(this.infowindow != null) {
+          // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
+          this.infowindow.setContent('<div style="padding:5px;font-size:12px;">' + place.place_name + '</div>');
+          this.infowindow.open(this.map, marker);
+        }
+      });
+    },
+    search: function() {
+      if(this.ps != null) {
+        this.ps.keywordSearch(this.searchText, this.placesSearchCB);
+        this.searchText = ''
+      }
+    },
+    addMarker: function (position: any, place: { y: any; x: any; place_name: string; road_address_name:string; category_name: string }) {
+      // 마커를 생성합니다
+      const marker = new kakao.maps.Marker({
+        position: position
+      });
+      // 마커가 지도 위에 표시되도록 설정합니다
+      marker.setMap(this.map);
+      // 생성된 마커를 배열에 추가합니다
+      this.markers.push(marker);
+      // 마커에 클릭이벤트를 등록합니다
+      kakao.maps.event.addListener(marker, 'click', () => {
+        this.placeName = place.place_name
+        this.placeAddress = place.road_address_name
+        this.placeCategory = place.category_name.split(' > ')
+        if(this.infowindow != null) {
+          // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
+          this.infowindow.setContent('<div style="padding:5px;font-size:12px;">' + place.place_name + '</div>');
+          this.infowindow.open(this.map, marker);
+        }
+      });
+    },
+    // 배열에 추가된 마커들을 지도에 표시하거나 삭제하는 함수입니다
+    setMarkers: function(map: any) {
+      for (let i = 0; i < this.markers.length; i++) {
+        this.markers[i].setMap(map);
+      }
+    },
+    // "마커 보이기" 버튼을 클릭하면 호출되어 배열에 추가된 마커를 지도에 표시하는 함수입니다
+    showMarkers: function() {
+      this.setMarkers(this.map)
+    },
+    // "마커 감추기" 버튼을 클릭하면 호출되어 배열에 추가된 마커를 지도에서 삭제하는 함수입니다
+    hideMarkers: function() {
+      this.setMarkers(null);
+    },
+    showPlace: function (id: number) {
+      this.initMap()
+      setTimeout(()=>{
+        // MARK: 기존 마커 삭제
+        if(this.markers.length !== 0) {
+          if(this.infowindow != null) {
+            this.infowindow.close()
+          }
+          for(let i = 0; i < this.markers.length; i++) {
+            this.markers[i].setMap(null)
+          }
+          this.markers = []
+        }
+        // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+        // LatLngBounds 객체에 좌표를 추가합니다
+        const bounds = new kakao.maps.LatLngBounds();
+        this.places = []
+        this.placesInfos[id].forEach((place: { y: any; x: any; place_name: string; road_address_name:string; category_name: string })=> {
+          this.places.push(place)
+          this.addMarker(new kakao.maps.LatLng(parseFloat(place.y), parseFloat(place.x)), place);
+          bounds.extend(new kakao.maps.LatLng(parseFloat(place.y), parseFloat(place.x)));
+        })
+        if(this.map != null) {
+          // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+          this.map.setBounds(bounds);
+        }
+      },200)
+    }
+  },
+});
+</script>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -9,7 +9,17 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/main',
     component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/MainPage.vue') }],
+    children: [
+      { path: '', component: () => import('pages/MainPage.vue') },
+    ],
+  },
+  {
+    path: '/article',
+    component: () => import('layouts/ArticleLayout.vue'),
+    children: [
+      { path: 'themes', component: () => import('pages/article/ThemesPage.vue') },
+      { path: 'write', component: () => import('pages/article/WritePage.vue') },
+    ],
   },
   // Always leave this as last one,
   // but you can also remove it


### PR DESCRIPTION
- 목업 기반 게시물 추가 페이지 작성 
    - 좌측 사이드바 '게시물 작성' 페이지 이동을 통해 데모 사용 가능

#### article/themes
- 기존 태그 선택, 새로운 태그 추가
- 좌측 하단 '추가하기' 통해 새 태그 추가 가능
- 기존 태그 선택 후 우측 하단 계속 작성하기 버튼을 통해 기존 태그 변경 가능

#### article/write
- 지도 기반 태그
- 하드코딩된 데이터만 불러올 수 있어서 상명대 주변 맛집만 보여요
